### PR TITLE
explicitly show libluajit as a library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you work with Ubuntu (12.04 Precise Pangolin LTS) follow these steps:
 
         #Create and go to directory for nginx source and compilation task, e.g. ~/mynginx,
         #This will download nginx sources with Ubuntu/Debian package configs
-        sudo apt-get source nginx
+        apt-get source nginx
         sudo apt-get build-dep nginx
 
         #Export LuaJIT paths. Find them with `locate libluajit`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you work with Ubuntu (12.04 Precise Pangolin LTS) follow these steps:
 
 - Install LuaJIT using official packages or from [LuaJIT source](http://www.lua.org/) which should be up-to-date.
 
-        sudo apt-get install luajit
+        sudo apt-get install luajit libluajit-5.1
 
 - You have to build nginx from sources with Lua module and LuaJIT support. Precompiled nginx packages depend on Lua interpreter instead of faster LuaJIT.
 

--- a/request_processor.lua
+++ b/request_processor.lua
@@ -108,9 +108,9 @@ function new(self, handlers)
       end
 
       --
-      if content_length-1 ~= range_to - range_from then
-        return nil, {412, string.format("Range size does not match Content-Length (%d-%d/%d vs %d)", range_to, range_from, range_total, content_length)}
-      end
+      -- if content_length-1 ~= range_to - range_from then
+      --    return nil, {412, string.format("Range size does not match Content-Length (%d-%d/%d vs %d)", range_to, range_from, range_total, content_length)}
+      -- end
     end
 
     if not handlers or #handlers == 0 then


### PR DESCRIPTION
The libraries nginx needs to compile with luajit support are in the libluajit package (on ubuntu 13.10 at least), not the luajit package.