### PR TITLE
Switch to new Lua module syntax (5.1+)

### DIFF
--- a/lib/backend_file_storage_handler.lua
+++ b/lib/backend_file_storage_handler.lua
@@ -11,8 +11,7 @@ local string = string
 local concat = table.concat
 local error = error
 
-
-module(...)
+local _M = {}
 
 local function end_backend(self, ctx)
   -- last chunk commited?
@@ -47,7 +46,6 @@ local function on_body_end(self, ctx)
   return {201, string.format("0-%d/%d", ctx.range_to, ctx.range_total), response = res }
 end
 
-
 function _M:new(dir, backend)
     if not backend then
       return nil, "Configuration error: no backend specified"
@@ -61,7 +59,6 @@ function _M:new(dir, backend)
     return setmetatable(inst, { __index = function(t,k) return t.super[k] end} )
 end
 
-
 setmetatable(_M, {
   __newindex = function (_, n)
     error("attempt to write to undeclared variable "..n, 2)
@@ -70,3 +67,5 @@ setmetatable(_M, {
     error("attempt to read undeclared variable "..n, 2)
   end,
 })
+
+return _M

--- a/lib/crc32.lua
+++ b/lib/crc32.lua
@@ -8,27 +8,25 @@ local string = string
 local ngx = ngx
 local table = table
 
-module(...)
-
 local zlib = ffi.load('z')
 ffi.cdef[[
     unsigned long crc32(unsigned long crc, const char *buf, unsigned len );
 ]]
 
-function crc32(data, lastnum)
+local function crc32(data, lastnum)
   return tonumber(zlib.crc32(lastnum, data, #data))
 end
 
-function validhex(crchex) return #crchex <= 8 and string.match(crchex, "^%x+$") end
-function tohex(crcnum) return string.format("%08.8x", crcnum) end
+local function validhex(crchex) return #crchex <= 8 and string.match(crchex, "^%x+$") end
+local function tohex(crcnum) return string.format("%08.8x", crcnum) end
 
-function crc32hex(data, last)
+local function crc32hex(data, last)
   local lastnum = last and tonumber(last, 16) or 0
   local currnum = crc32(data,lastnum)
   return tohex(tonumber(currnum))
 end
 
-function handler()
+local function handler()
   return {
     on_body_start = function (self, ctx)
       ctx.current_checksum = ctx.last_checksum and tonumber(ctx.last_checksum, 16) or ( ctx.first_chunk and 0 )
@@ -55,3 +53,11 @@ function handler()
     end
   }
 end
+
+return {
+  handler = handler,
+  crc32 = crc32,
+  validhex = validhex,
+  tohex = tohex,
+  crc32hex = crc32hex
+}

--- a/lib/crc32_server.lua
+++ b/lib/crc32_server.lua
@@ -12,8 +12,6 @@ local concat = table.concat
 local util = require('util')
 local crc32 = require('crc32')
 
-module(...)
-
 local function crc32h_to_file(file_path, hex_checksum, offset)
   local out = assert(io.open(file_path .. '.crc32', "wb"))
   out:write(offset)
@@ -33,8 +31,7 @@ local function crc32_from_file(file_path)
   return
 end
 
-
-function handler(storage_path)
+local function handler(storage_path)
   return {
     on_body_start = function(self, ctx)
       self.skip_bytes = 0
@@ -83,3 +80,7 @@ function handler(storage_path)
     end
   }
 end
+
+return {
+  handler = handler
+}

--- a/lib/file_storage_handler.lua
+++ b/lib/file_storage_handler.lua
@@ -5,7 +5,6 @@
 -- after successfully submitting last chunk of file. Then the backend should look for file named as
 -- Session-ID in the upload directory.
 
-
 local setmetatable = setmetatable
 local concat = table.concat
 local io = io
@@ -13,10 +12,9 @@ local string = string
 local error = error
 local ngx = ngx
 
-module(...)
+local _M = {}
 
 -- local mt = { __index = _M }
-
 
 local function init_file(self, ctx)
   local file_path = ctx.file_path
@@ -78,7 +76,6 @@ local function on_body_end(self, ctx)
   return {201, string.format("0-%d/%d", ctx.range_to, ctx.range_total) }
 end
 
-
 function _M:new(dir)
     return setmetatable({
        dir = dir or '/tmp',
@@ -95,7 +92,6 @@ function _M:new(dir)
     }, _M)
 end
 
-
 setmetatable(_M, {
   __newindex = function (_, n)
     error("attempt to write to undeclared variable "..n, 2)
@@ -104,3 +100,5 @@ setmetatable(_M, {
     error("attempt to read undeclared variable "..n, 2)
   end,
 })
+
+return _M

--- a/lib/request_processor.lua
+++ b/lib/request_processor.lua
@@ -11,13 +11,12 @@ local math = math
 local ngx = ngx
 local type = type
 local ipairs = ipairs
-local crc32 = crc32
-local sha1_handler = sha1_handler
+local crc32 = require('crc32')
+local sha1_handler = require('sha1_handler')
 local io = io
 local util = require('util')
 
-
-module(...)
+local _M = {}
 
 local mt = { __index = _M }
 
@@ -40,10 +39,8 @@ local function raw_body_by_chunk(self)
     return chunk
 end
 
-
-
 -- Checks request headers and creates upload context instance
-function new(self, handlers)
+function _M.new(self, handlers)
     local ctx = {}
     local headers = ngx.req.get_headers()
 
@@ -191,7 +188,7 @@ local function prepopulate_response_headers(ctx)
     ngx.header['X-Session-Id'] = ctx.id
 end
 
-function process(self)
+function _M.process(self)
     prepopulate_response_headers(self.payload_context)
 
     for i, h in ipairs(self.handlers) do
@@ -232,3 +229,4 @@ setmetatable(_M, {
   end,
 })
 
+return _M

--- a/lib/sha1_handler.lua
+++ b/lib/sha1_handler.lua
@@ -12,9 +12,7 @@ local assert = assert
 local concat = table.concat
 local util = require('util')
 
-module(...)
-
-function validhex(sha1hex) return #sha1hex <= 40 and string.match(sha1hex, "^%x+$") end
+local function validhex(sha1hex) return #sha1hex <= 40 and string.match(sha1hex, "^%x+$") end
 
 local crypto = ffi.load('crypto')
 
@@ -59,8 +57,7 @@ local function shactx_from_file(file_path)
   return
 end
 
-
-function handler(storage_path)
+local function handler(storage_path)
   return {
 
     on_body_start = function (self, ctx)
@@ -124,3 +121,8 @@ function handler(storage_path)
     end
   }
 end
+
+return {
+  handler = handler,
+  validhex = validhex
+}

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -1,19 +1,22 @@
 local string = string
 local io = io
 
-module(...)
-
 -- Convert any binary string to hex
-function tohex(str)
+local function tohex(str)
     return (str:gsub('.', function (c)
         return string.format('%02x', string.byte(c))
     end))
 end
 
 -- This is random string generator generating SHA1 compatible strings
-function random_sha1()
+local function random_sha1()
     local ur = io.open("/dev/urandom", "r")
     local random_bin = ur:read(20)  -- loads 160 bits
     ur:close()
     return tohex(random_bin)  -- returns 40 hexadecimal characters
 end
+
+return {
+  tohex = tohex,
+  random_sha1 = random_sha1
+}


### PR DESCRIPTION
Currently the old Lua 5.0 module syntax is used (deprecated `module() ` function).
After this change latest ngx_lua modules don't complain about the usage of global variables in modules anymore.

Bumps required Lua version to 5.1 but this shouldn't be a problem.